### PR TITLE
fix: action will only allow unique inputs for its mappingpoints when …

### DIFF
--- a/src/main/java/org/ironsight/wpplugin/macromachine/Gui/MacroDesigner.java
+++ b/src/main/java/org/ironsight/wpplugin/macromachine/Gui/MacroDesigner.java
@@ -55,7 +55,7 @@ public class MacroDesigner extends JPanel {
                 ActionFilterIO.instance,
                 new MappingPoint[]{
                         new MappingPoint(0, ActionFilterIO.BLOCK_VALUE),
-                        new MappingPoint(0, ActionFilterIO.PASS_VALUE)
+                        new MappingPoint(1, ActionFilterIO.PASS_VALUE)
                 },
                 ActionType.LIMIT_TO,
                 "Filter: Only On Water",

--- a/src/main/java/org/ironsight/wpplugin/macromachine/operations/MappingAction.java
+++ b/src/main/java/org/ironsight/wpplugin/macromachine/operations/MappingAction.java
@@ -46,11 +46,17 @@ public class MappingAction implements SaveableAction {
         this.actionType = type;
         this.uid = uid;
 
+        HashSet<Integer> seenInputValues = new HashSet<>();
         //filter out illegal mapping points (user might have edited save file)
         mappingPoints =
                 Arrays.stream(mappingPoints)
                         .filter(p -> sanitizeInput(p.input) == p.input) //input points
                         .map(p -> new MappingPoint(p.input, sanitizeOutput(p.output)))
+                        .filter(p -> { //only unique inputs.
+                            boolean alreadyExists = seenInputValues.contains(p.input);
+                            seenInputValues.add(p.input);
+                            return !alreadyExists;
+                        })
                         .toArray(MappingPoint[]::new);
 
         assert Arrays.stream(mappingPoints).noneMatch(p -> sanitizeInput(p.input) != p.input) : "mapping points " +

--- a/src/test/java/org/ironsight/wpplugin/macromachine/Gui/MappingActionValueTableModelTest.java
+++ b/src/test/java/org/ironsight/wpplugin/macromachine/Gui/MappingActionValueTableModelTest.java
@@ -29,6 +29,13 @@ class MappingActionValueTableModelTest {
         model.rebuildDataWithAction(action);
         assertEquals(action, model.constructMapping());
 
+        for (MappingPoint mp: action.getMappingPoints()) {
+            int row = mp.input;
+            assertTrue(model.isMappingPoint(row));
+            assertTrue(model.isCellEditable(row,0));
+            assertTrue(model.isCellEditable(row,1));
+
+        }
     }
 
     @Test


### PR DESCRIPTION
…instantiating.

fix too: only on water incorrectly used input=0 twice